### PR TITLE
Add file attachment functionality to email composer

### DIFF
--- a/app/sendmail/actions.ts
+++ b/app/sendmail/actions.ts
@@ -14,6 +14,18 @@ export async function sendEmail(formData: FormData) {
   const to = formData.get('to') as string
   const subject = formData.get('subject') as string
   const body = formData.get('body') as string
+  
+  // Process attachments
+  const attachments = []
+  for (const [key, value] of formData.entries()) {
+    if (key.startsWith('attachment') && value instanceof File) {
+      const buffer = await value.arrayBuffer()
+      attachments.push({
+        filename: value.name,
+        content: Buffer.from(buffer),
+      })
+    }
+  }
 
   try {
     const { data, error } = await resend.emails.send({
@@ -21,6 +33,7 @@ export async function sendEmail(formData: FormData) {
       to,
       subject,
       html: body,
+      attachments: attachments,
     })
 
     if (error) {


### PR DESCRIPTION
# Add File Attachment Functionality to Email Composer

## Description
This PR adds the ability to attach files to emails sent through our Next Resend application. Users can now attach multiple files to their emails before sending them via the Resend API.

## Features
- Add file attachment button in the email composer
- Support for selecting multiple files
- Visual display of attached files with file names
- Ability to remove individual attachments
- Server-side processing of file attachments
- Integration with Resend API for sending attachments

## Implementation Details
- Added file input and attachment handling to the EmailForm component
- Updated the server action to process file attachments
- Implemented file conversion to the format required by Resend API
- Added UI elements for managing attachments
- Improved user feedback during the attachment process

## Technical Changes
- Added file input with reference for programmatic access
- Implemented state management for attached files
- Added UI for displaying and managing attachments
- Updated form submission to include file data
- Modified server action to extract and process file attachments
- Integrated with Resend API's attachment functionality

## Testing Instructions
1. Checkout this branch
2. Run the application locally
3. Navigate to the email composer page
4. Try attaching various file types (images, documents, etc.)
5. Verify that attached files appear in the UI
6. Test removing individual attachments
7. Send a test email with attachments to verify end-to-end functionality


## Dependencies
- This feature requires the `react-quill` package to be installed

## Notes
- Maximum file size and attachment limits are determined by the Resend API
- The application handles multiple file types as supported by the Resend API